### PR TITLE
ci(travis): remove deprecated sudo option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ go:
 
 install: true
 
-sudo: false
-
 matrix:
   allow_failures:
     - go: master


### PR DESCRIPTION
Travis is removing the `false` option soon, and the default is basically the same so better to be safe then sorry